### PR TITLE
Add ESLint with React/a11y rules and lint script (#4)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+.cache
+public
+static
+coverage

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,33 @@
+// ESLint configuration for the Gatsby blog.
+// Extends Create React App's config (React/hooks/jsx-a11y/import rules), then
+// disables any formatting-related rules so Prettier (see .prettierrc) owns
+// stylistic choices and the two tools don't fight.
+module.exports = {
+  root: true,
+  extends: ["react-app", "prettier"],
+  env: {
+    browser: true,
+    node: true,
+    es6: true,
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+  rules: {
+    // Gatsby uses styled-components / MDX / etc.; PropTypes are widely omitted
+    // in this codebase, so don't fail the build on missing prop-type declarations.
+    "react/prop-types": "off",
+  },
+  overrides: [
+    {
+      // Gatsby lifecycle files run in Node and use CommonJS.
+      files: ["gatsby-node.js", "gatsby-config.js", "gatsby-ssr.js", "gatsby-browser.js"],
+      env: {
+        node: true,
+        browser: false,
+      },
+    },
+  ],
+}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
     Open the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
+## 🧪 Development scripts
+
+- `npm run develop` — start the Gatsby development server.
+- `npm run build` — produce a production build in `public/`.
+- `npm run serve` — serve the production build locally.
+- `npm run format` — run Prettier over the repo (writes fixes).
+- `npm run lint` — run ESLint over `src/**/*.{js,jsx,tsx}` and the `gatsby-*.js` config files. Uses `eslint-config-react-app` for React / hooks / jsx-a11y rules, with `eslint-config-prettier` disabling any stylistic rules that would conflict with `.prettierrc`.
+
 ## 🧐 What's inside?
 
 A quick look at the top-level files and directories you'll see in a Gatsby project.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,19 @@
     "styled-media-query": "^2.1.2"
   },
   "devDependencies": {
-    "prettier": "2.0.5"
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
+    "@typescript-eslint/parser": "^2.34.0",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-config-react-app": "^5.2.1",
+    "eslint-plugin-flowtype": "^3.13.0",
+    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "prettier": "2.0.5",
+    "typescript": "^3.9.10"
   },
   "keywords": [
     "gatsby"
@@ -51,6 +63,7 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "lint": "eslint \"src/**/*.{js,jsx,tsx}\" gatsby-*.js",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
Resolves the ESLint gap called out in issue #4.

## What's here

- **`.eslintrc.js`** — extends `eslint-config-react-app` (React / hooks / jsx-a11y / import correctness rules), then `eslint-config-prettier` at the tail so nothing ESLint says fights with the existing `.prettierrc` (`arrowParens: avoid`, `semi: false`). `react/prop-types` is turned off because the codebase omits PropTypes widely and we don't want lint blocking on that today. A small override for `gatsby-*.js` lifecycle files lints them as Node scripts.
- **`.eslintignore`** — skips `.cache`, `public`, `static`, `node_modules`, `coverage`.
- **`package.json`** — declares the ESLint stack in `devDependencies`. Versions are pinned to what Gatsby 2 already pulls transitively (`eslint@^6.8.0`, `eslint-config-react-app@^5.2.1`, plus `eslint-plugin-{react,react-hooks,jsx-a11y,import,flowtype}`, `babel-eslint`, `@typescript-eslint/{parser,eslint-plugin}`, `typescript`, `eslint-config-prettier`) to avoid npm resolution conflicts. Adds `npm run lint` (`eslint "src/**/*.{js,jsx,tsx}" gatsby-*.js`).
- **`README.md`** — a new "Development scripts" section documents `lint` alongside the existing scripts.

## Verification

- `npm run lint` exits 0 against the current tree — no baseline of pre-existing errors/warnings to document.
- Re-ran with `--max-warnings 0` to confirm nothing is hidden.
- Canary check: a temporary `const unused = 1` in a fresh `.js` file is correctly flagged as `no-unused-vars` warning.
- Covered files: 58 JS/JSX/TSX files under `src/` (including `src/pages/using-typescript.tsx`) plus all four `gatsby-*.js` config files.

## Acceptance checklist

- [x] `npm run lint` exists and runs cleanly against `src/**`, `gatsby-node.js`, `gatsby-config.js`, `gatsby-browser.js`, `gatsby-ssr.js`.
- [x] `eslint` and required plugins added to `devDependencies`.
- [x] Root ESLint config committed; does not conflict with `.prettierrc` (via `eslint-config-prettier`).
- [x] README's development section documents the new `lint` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)