### PR TITLE
Fix missing React key prop on post list items in blog-list.js

### DIFF
--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -30,6 +30,7 @@ const BlogList = props => {
             },
           }) => (
             <PostItem
+              key={slug}
               slug={slug}
               background={background}
               category={category}


### PR DESCRIPTION
## Summary

Fixes Task #6. The `postList.map()` in `src/templates/blog-list.js` — which renders the homepage and every `/page/N` pagination route — was rendering `<PostItem />` without a `key` prop, triggering React's *"Each child in a list should have a unique key prop"* warning and, more importantly, risking DOM node misassociation across re-renders (stale link targets, lost focus/scroll state) when navigating between pagination pages.

## Change

Added `key={slug}` to `<PostItem />` in `src/templates/blog-list.js`. `slug` is already destructured, is guaranteed unique per post, and is stable across renders (preferred over an array index).

## Verification

- Confirmed via `grep -rn "\.map(" src/` that every other list render in `src/components` and `src/templates` (`Breadcrumbs`, `TableOfContents`, `SocialLinks`, `MenuLinks`) already passes a `key` — `blog-list.js` was the only offender.
- Diff is minimal (one line added).
- No lint/test script is configured in this project (`package.json` only has `build`, `develop`, `format`, `serve`, `clean`), so no automated check to run.

## Acceptance criteria

- [x] `<PostItem />` in `src/templates/blog-list.js` receives a unique `key` (`key={slug}`).
- [x] No other unkeyed list renders remain in `src/`.
- [ ] No console warning when running `gatsby develop` and viewing `/` or `/page/2` — not run here (no dev server in this environment); reviewer can spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)