### PR TITLE
Handle and report GraphQL errors in gatsby-node.js createPages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,9 +25,9 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 }
 
 // To create the posts pages
-exports.createPages = ({ graphql, actions }) => {
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
-  return graphql(`
+  const result = await graphql(`
     query PostList {
       allMarkdownRemark(sort: { fields: frontmatter___date, order: DESC }) {
         edges {
@@ -41,15 +41,15 @@ exports.createPages = ({ graphql, actions }) => {
               date(locale: "pt-br", formatString: "DD [de] MMMM [de] YYYY")
               description
               title
-              image 
+              image
             }
             timeToRead
-          }          
+          }
           next {
             frontmatter {
               title
             }
-            fields{
+            fields {
               slug
             }
           }
@@ -57,44 +57,52 @@ exports.createPages = ({ graphql, actions }) => {
             fields {
               slug
             }
-            frontmatter{
+            frontmatter {
               title
             }
           }
         }
       }
     }
-  `).then(result => {
-    const posts = result.data.allMarkdownRemark.edges
+  `)
 
-    posts.forEach(({ node, next, previous }) => {
-      createPage({
-        path: node.fields.slug,
-        component: path.resolve(`./src/templates/blog-post.js`),
-        context: {
-          // Data passed to context is available
-          // in page queries as GraphQL variables.
-          slug: node.fields.slug,
-          previousPost: next,
-          nextPost: previous
-        },
-      })
+  if (result.errors) {
+    reporter.panicOnBuild(
+      `Error loading markdown posts for page creation`,
+      result.errors
+    )
+    return
+  }
+
+  const posts = result.data.allMarkdownRemark.edges
+
+  posts.forEach(({ node, next, previous }) => {
+    createPage({
+      path: node.fields.slug,
+      component: path.resolve(`./src/templates/blog-post.js`),
+      context: {
+        // Data passed to context is available
+        // in page queries as GraphQL variables.
+        slug: node.fields.slug,
+        previousPost: next,
+        nextPost: previous,
+      },
     })
+  })
 
-    const postPerPage = 6
-    const numPages = Math.ceil(posts.length / postPerPage)
+  const postPerPage = 6
+  const numPages = Math.ceil(posts.length / postPerPage)
 
-    Array.from({ length: numPages }).forEach((_, index) => {
-      createPage({
-        path: index === 0 ? `/` : `/page/${index + 1}`,
-        component: path.resolve(`./src/templates/blog-list.js`),
-        context: {
-          limit: postPerPage,
-          skip: index * postPerPage,
-          numPages,
-          currentPage: index + 1,
-        },
-      })
+  Array.from({ length: numPages }).forEach((_, index) => {
+    createPage({
+      path: index === 0 ? `/` : `/page/${index + 1}`,
+      component: path.resolve(`./src/templates/blog-list.js`),
+      context: {
+        limit: postPerPage,
+        skip: index * postPerPage,
+        numPages,
+        currentPage: index + 1,
+      },
     })
   })
 }


### PR DESCRIPTION
## Summary

`createPages` in `gatsby-node.js` ran `graphql(...).then(result => result.data.allMarkdownRemark.edges)` with no error check. Because Gatsby's `graphql()` **resolves** (doesn't reject) when the query has errors, `result.data` is `null` and the very next line throws a cryptic `TypeError: Cannot read properties of null (reading 'allMarkdownRemark')` — hiding the actual GraphQL error message and field path.

This is a real risk for this repo: an involved query (frontmatter fields, `next`/`previous`, `timeToRead`) plus a pending Gatsby/plugin upgrade (#1) means schema shifts are exactly the scenario where the query is likely to break. Without proper handling, you'd chase a null-dereference instead of seeing the actual GraphQL error.

## Changes

`gatsby-node.js`:
- Converted `createPages` to `async/await` (idiomatic Gatsby pattern).
- Destructured `reporter` from the API args.
- Check `result.errors` after `await graphql(...)`; if present, call `reporter.panicOnBuild('Error loading markdown posts for page creation', result.errors)` and `return` **before** touching `result.data`.
- Prettier normalized a few pre-existing whitespace nits that showed up in the rewrite (trailing spaces, missing space before `{`).

`onCreateNode` was left as-is per the task's "primary fix belongs in `createPages`" note.

## Verification

Ran `gatsby clean && gatsby build` against the real content in this repo:

**Happy path (unchanged query):**
```
success createPages - 0.072s
success run page queries - 0.013s - 7/7 559.90/s
success Building static HTML for pages - 2.126s - 13/13 6.12/s
```
All post pages + paginated `blog-list` pages generated. The only remaining error is a pre-existing `gatsby-plugin-algolia-search` credential error in `onPostBuild`, unrelated to this change.

**Broken query (added `deliberatelyBrokenFieldForErrorTest` to `PostList`, then reverted):**
```
ERROR #85923  GRAPHQL
There was an error in your GraphQL query:
Cannot query field "deliberatelyBrokenFieldForErrorTest" on type "MarkdownRemark".
If you don't expect "deliberatelyBrokenFieldForErrorTest" to exist on the type "MarkdownRemark" it is most likely a typo.
...
not finished createPages - 0.040s
```
Exactly what the task asked for — the actual GraphQL error surfaces, no null-dereference stack trace.

## Acceptance criteria

- [x] `createPages` checks `result.errors` and calls `reporter.panicOnBuild(...)` with a clear message before accessing `result.data`.
- [x] Introducing a broken field in the `PostList` query causes `gatsby build` to fail with the actual GraphQL error message, not a null-dereference.
- [x] Existing successful build/page-creation behavior (post + paginated `blog-list` pages) is unchanged when the query succeeds.

Closes task #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)