### PR TITLE
Fix Comments component hardcoding localhost:8000 as Disqus URL

### DIFF
--- a/src/components/Comments/index.js
+++ b/src/components/Comments/index.js
@@ -1,11 +1,26 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { useStaticQuery, graphql } from "gatsby"
 import ReactDisqusComments from "react-disqus-comments"
 
 import * as S from "./styled"
 
 const Comments = ({ url, title }) => {
-  const completeUrl = `http://localhost:8000${url}`
+  const {
+    site: {
+      siteMetadata: { siteUrl },
+    },
+  } = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          siteUrl
+        }
+      }
+    }
+  `)
+
+  const completeUrl = `${siteUrl.replace(/\/$/, "")}${url}`
 
   return (
     <S.CommentsWrapper>


### PR DESCRIPTION
## Summary

`src/components/Comments/index.js` was hardcoding `http://localhost:8000` as the Disqus `identifier`/`url`, meaning every production comment thread was registered under a localhost URL instead of the real post URL. This broke Disqus counts on the deployed site and made threads brittle to any future identifier changes.

## Change

Replace the hardcoded origin with `siteMetadata.siteUrl` fetched via `useStaticQuery`, mirroring the pattern already in `src/components/seo.js`. Trailing slashes on `siteUrl` are stripped before concatenating with the post slug (which already begins with `/`).

## Acceptance criteria

- ✅ `Comments` no longer contains the literal string `localhost:8000`; `identifier`/`url` are derived from `siteMetadata.siteUrl`.
- ✅ Prop contract (`url`, `title`) unchanged — no changes needed in `blog-post.js`.
- ✅ Dev experience unaffected — `siteUrl` is defined in `gatsby-config.js` for both `develop` and `build`.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)