### PR TITLE
Document required Algolia env vars via .env.example (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy this file to `.env` (or `.env.development` / `.env.production`) and fill
+# in real values. `.env*` files are gitignored, so real secrets stay local.
+# `gatsby-config.js` loads them via `require("dotenv").config()`.
+#
+# All four values come from your Algolia dashboard:
+#   https://www.algolia.com/account/api-keys/
+# Pick the application whose index you want the blog to read from and write to.
+
+# Algolia application id (public, safe to expose in the browser bundle).
+GATSBY_ALGOLIA_APP_ID=your-algolia-app-id
+
+# Algolia Admin API key. SECRET — never expose in the browser. Used at build
+# time by `gatsby-plugin-algolia-search` to push the search index.
+ALGOLIA_ADMIN_KEY=your-algolia-admin-key
+
+# Name of the Algolia index to read/write (e.g. `Pages`, `blog_posts`).
+GATSBY_ALGOLIA_INDEX_NAME=your-algolia-index-name
+
+# Algolia Search-Only API key. Public, ships in the browser bundle and is used
+# by `src/components/Search` to query the index from the client.
+GATSBY_ALGOLIA_SEARCH_KEY=your-algolia-search-only-key

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ typings/
 
 # dotenv environment variable files
 .env*
+# Keep the checked-in template so contributors know which vars to set (see README).
+!.env.example
 
 # gatsby files
 .cache/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
     Open the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
+## 🔑 Environment variables
+
+Both `gatsby-config.js` and `src/components/Search` read Algolia credentials
+from environment variables. `gatsby-config.js` loads them from a local `.env`
+file via `dotenv`, so before running `gatsby develop` or `gatsby build` you
+need to create one:
+
+```shell
+cp .env.example .env
+# then edit .env and fill in the values from https://www.algolia.com/account/api-keys/
+```
+
+The required keys are documented in [`.env.example`](./.env.example):
+
+| Variable | Where it's used | Notes |
+| --- | --- | --- |
+| `GATSBY_ALGOLIA_APP_ID` | build + browser | Algolia application id (public). |
+| `ALGOLIA_ADMIN_KEY` | build | Admin API key — **secret**, used to push the index. |
+| `GATSBY_ALGOLIA_INDEX_NAME` | build + browser | Name of the Algolia index to read/write. |
+| `GATSBY_ALGOLIA_SEARCH_KEY` | browser | Search-only API key used by the Search component. |
+
+Real `.env*` files are gitignored; only `.env.example` is checked in. If any
+of the three build-time vars are missing, `gatsby-config.js` will log a
+warning at startup so you can spot misconfigured environments (including CI)
+early.
+
 ## 🧐 What's inside?
 
 A quick look at the top-level files and directories you'll see in a Gatsby project.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,26 @@ require("dotenv").config()
 
 const queries = require('./src/utils/algollia_queries')
 
+// Warn (don't crash) when Algolia build-time credentials are missing. Without
+// these, `gatsby-plugin-algolia-search` silently receives `undefined` values
+// and either no-ops or errors deep inside the plugin — this surfaces the root
+// cause up front. See `.env.example` and the README for setup instructions.
+const requiredAlgoliaEnvVars = [
+  'GATSBY_ALGOLIA_APP_ID',
+  'ALGOLIA_ADMIN_KEY',
+  'GATSBY_ALGOLIA_INDEX_NAME',
+]
+const missingAlgoliaEnvVars = requiredAlgoliaEnvVars.filter(
+  (name) => !process.env[name]
+)
+if (missingAlgoliaEnvVars.length > 0) {
+  console.warn(
+    `[gatsby-config] Missing Algolia environment variable(s): ${missingAlgoliaEnvVars.join(
+      ', '
+    )}. Copy .env.example to .env and fill in values from https://www.algolia.com/account/api-keys/ — see README.md for details.`
+  )
+}
+
 
 module.exports = {
   siteMetadata: {


### PR DESCRIPTION
## Summary

Closes #9. Adds a checked-in `.env.example` documenting the four Algolia-related environment variables read by `gatsby-config.js` and `src/components/Search`, plus README instructions and a fail-fast warning at Gatsby startup.

Previously a fresh clone (or CI runner) had no way to discover `GATSBY_ALGOLIA_APP_ID`, `ALGOLIA_ADMIN_KEY`, `GATSBY_ALGOLIA_INDEX_NAME`, and `GATSBY_ALGOLIA_SEARCH_KEY` without grepping source, and missing values silently propagated as `undefined` into `gatsby-plugin-algolia-search`.

## Changes

- **`.env.example`** — new file at repo root listing the four keys with placeholder values, per-variable comments (public vs. secret, where it's used), and a pointer to the Algolia dashboard.
- **`.gitignore`** — adds `!.env.example` after the `.env*` rule so the template is tracked while real `.env` files remain local. Verified via `git check-ignore` that the template is no longer ignored.
- **`README.md`** — adds a "🔑 Environment variables" section with a `cp .env.example .env` quickstart and a table summarizing each variable.
- **`gatsby-config.js`** — stretch goal: warns at startup when any of the three build-time Algolia vars are missing, with a message pointing at `.env.example`/README.

## Verification

- `node -e "require('./gatsby-config.js')"` with all Algolia vars unset → warning printed, config loads (14 plugins).
- Same with vars set → silent, config loads.
- `git check-ignore -v .env.example` → matches the `!.env.example` negation, i.e. no longer ignored.

## Acceptance criteria

- [x] `.env.example` exists at repo root with all four Algolia keys documented (placeholders only, no real secrets).
- [x] README documents how to set up local env vars before `gatsby develop`/`gatsby build`.
- [x] `.env.example` is exempt from the `.env*` gitignore rule (verified).
- [x] (Stretch) `gatsby-config.js` logs a clear warning when required build-time Algolia vars are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)