### PR TITLE
chore(dev): add Husky + lint-staged pre-commit hook (Prettier)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ A quick look at the top-level files and directories you'll see in a Gatsby proje
 
 12. **`README.md`**: A text file containing useful reference information about your project.
 
+## 🧹 Code formatting & pre-commit hook
+
+This project uses [Prettier](https://prettier.io/) via a Git pre-commit hook powered by [Husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/okonet/lint-staged).
+
+- The hook is installed automatically after `npm install` by the `prepare` script (`husky install`). No manual setup is required.
+- On every `git commit`, staged `*.{js,jsx,ts,tsx,json,md}` files are auto-formatted with `prettier --write` before the commit is created. Only staged files are touched, so unrelated commits stay fast.
+- You may see your staged files reformatted mid-commit — this is expected. The reformatted changes are added to the same commit automatically by lint-staged.
+- To format the entire repository on demand, run `npm run format`.
+
+If you ever need to bypass the hook (e.g. for a WIP commit), use `git commit --no-verify`.
+
 ## 🎓 Learning Gatsby
 
 Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.org/). Here are some places to start:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "styled-media-query": "^2.1.2"
   },
   "devDependencies": {
+    "husky": "^8.0.3",
+    "lint-staged": "^13.3.0",
     "prettier": "2.0.5"
   },
   "keywords": [
@@ -54,7 +56,11 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,json,md}": "prettier --write"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #10

## What

Adds automated Prettier formatting via a Git pre-commit hook powered by [Husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/okonet/lint-staged).

## Why

`package.json` already had a `format` script and `.prettierrc`, but nothing enforced them. Formatting only happened when a developer remembered to run `npm run format` manually. This is cheap tech debt to pay down now, before ESLint (#4) and Jest (#3) land, so those future hooks can layer onto the same infrastructure instead of everyone bolting it on ad hoc.

## Changes

- **`package.json`** — adds `husky@^8.0.3` and `lint-staged@^13.3.0` as devDependencies (pinned to versions that still support Node 14+ per `.nvmrc`); adds `"prepare": "husky install"` so hooks install automatically after `npm install`; adds inline `lint-staged` config running `prettier --write` on staged `*.{js,jsx,ts,tsx,json,md}` files (same glob as the existing `format` script).
- **`.husky/pre-commit`** — new executable hook that invokes `npx lint-staged`. Scoped to staged files only, so commits touching unrelated files stay fast.
- **`README.md`** — adds a "Code formatting & pre-commit hook" section documenting how the hook works, why staged files may be reformatted mid-commit, and the `--no-verify` escape hatch.

## Verification

End-to-end tested in an isolated scratch git repo (fresh `npm install`):

1. ✅ `prepare` script ran automatically → `git config core.hooksPath` set to `.husky`, no manual setup required.
2. ✅ Staged a deliberately misformatted `.js` file (`const   x=1` etc.) and ran `git commit` → Prettier reformatted it (removed extra spaces, applied `arrowParens: avoid` and `semi: false` from `.prettierrc`) and the commit landed with the formatted content.
3. ✅ Committed a `.txt` file → lint-staged printed "No staged files match any configured task" and did nothing else, confirming the hook is scoped.

## Acceptance criteria

- [x] `npm install` sets up the git hook automatically via `prepare` — no manual step.
- [x] Staging a misformatted `.js` file and committing auto-formats it via Prettier.
- [x] `package.json` gains `husky`/`lint-staged` devDependencies + `lint-staged` config scoped to the same glob as `format`.
- [x] Hook is scoped to staged files only (not a repo-wide `format` run).

## Notes for reviewers

- The task description mentioned `pnpm install`, but this repo has `package-lock.json` (not `pnpm-lock.yaml`), so I stuck with `npm`. The `prepare` script works identically under either package manager.
- Husky v8 (not v9) was chosen because `.nvmrc` pins Node 16; husky v9 and lint-staged v15 both require Node 18+.
- Husky's auto-generated `.husky/_/` directory contains its own `.gitignore` (`*`), so it's automatically excluded — no root `.gitignore` change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)