### PR TITLE
feat(post): add sticky table of contents with active section tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+# (no trailing slash so the node_modules symlink in kanbots worktrees is also ignored)
+node_modules
 jspm_packages/
 
 # Typescript v1 declaration files

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,22 @@ const { createFilePath } = require(`gatsby-source-filesystem`)
 
 // You can delete this file if you're not using it
 // To add the slug field to each post
+
+// `frontmatter.image` holds site-relative paths like `/assets/img/cover.webp`.
+// Because `static/assets/img` is also a gatsby-source-filesystem source (and
+// gatsby-remark-relative-images rewrites the relative variants), inference
+// would type the field as `File`, breaking every query/consumer that treats
+// it as a plain string (PostList below, the post page query and SEO).
+// Pinning it to String keeps the raw path value.
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type MarkdownRemarkFrontmatter {
+      image: String
+    }
+  `)
+}
+
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
   // Ensures we are processing only markdown files

--- a/posts/2020-09-09-publicando-gatsby-no-docker.md
+++ b/posts/2020-09-09-publicando-gatsby-no-docker.md
@@ -3,7 +3,7 @@ title: Publicando gatsby no docker
 description: Passo a passo para publicar uma aplicação gatsby em um container
   utilizando o apache
 date: 2020-09-09T11:06:36.000Z
-image: assets/img/gatsby_docker.png
+image: /assets/img/gatsby_docker.png
 category: "DevOps"
 background: "#637a91"
 ---

--- a/posts/2023-10-13-autenticação-e-autorização-em-api-asp-net-utilizando-jwt-e-bearer-token.md
+++ b/posts/2023-10-13-autenticação-e-autorização-em-api-asp-net-utilizando-jwt-e-bearer-token.md
@@ -3,7 +3,7 @@ title: Autenticação e autorização em Api ASP.NET utilizando JWT e Bearer Tok
 description: Principais conceitos de segurança e autenticação aplicados em uma
   api desenvolvida em .Net Core.
 date: 2023-10-13 11:15:56
-image: assets/img/images.jpeg
+image: /assets/img/images.jpeg
 category: ".NET"
 background: "#637a91"
 ---

--- a/posts/2023-11-07-integrando-obfuscação-de-código-javascript-em-projetos-net-core.md
+++ b/posts/2023-11-07-integrando-obfuscação-de-código-javascript-em-projetos-net-core.md
@@ -3,7 +3,7 @@ title: "Ofuscação de código em Projetos .NET com JavaScript Obfuscator "
 description: Este artigo explora a integração eficaz da ofuscação de código
   JavaScript em projetos .NET Core.
 date: 2023-11-07T08:44:51.000Z
-image: assets/img/javascript-obfuscator.webp
+image: /assets/img/javascript-obfuscator.webp
 category: "Security"
 background: "#637a91"
 ---

--- a/posts/2026-01-27-engenharia-de-prompts-para-desenvolvedores.md
+++ b/posts/2026-01-27-engenharia-de-prompts-para-desenvolvedores.md
@@ -2,7 +2,7 @@
 title: "Engenharia de Prompt para Desenvolvedores de Software: Arquiteturas de Instrução no Software 3.0"
 description: Fundamentos, Técnicas Avançadas e Aplicações Práticas no Desenvolvimento de Software Orientado por LLMs
 date: 2026-01-27 07:43:09
-image: assets/img/javascript-obfuscator.webp
+image: /assets/img/javascript-obfuscator.webp
 category: "AI Engineering"
 background: "#637a91"
 ---

--- a/src/components/Post/styled.js
+++ b/src/components/Post/styled.js
@@ -1,15 +1,52 @@
 import styled from "styled-components"
 import media from "styled-media-query"
 
-// Single reading column — controls the shared width and horizontal padding
-// for every article element (breadcrumb, header, body, code, related).
-export const Column = styled.div`
+// Desktop two-column wrapper. When a non-empty <aside> (the TOC sidebar) is
+// present, it switches to a 2-column grid that comfortably hosts a sticky
+// TOC on the left and the article column on the right. When no aside is
+// present (e.g. articles without h2/h3), the grid collapses to a single
+// column so we never leave an empty sidebar taking up space.
+export const LayoutGrid = styled.div`
   max-width: 680px;
   margin: 0 auto;
-  padding: 0 32px;
+  padding: 0 20px;
 
-  ${media.lessThan("large")`
-    padding: 0 20px;
+  ${media.greaterThan("large")`
+    max-width: 1200px;
+    padding: 0 32px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    justify-content: center;
+    align-items: start;
+    gap: 3.5rem;
+
+    &:has(> aside:not(:empty)) {
+      grid-template-columns: 240px minmax(0, 680px);
+    }
+  `}
+`
+
+// Right-hand reading column that owns PostHeader, MainContent, and
+// RecommendedPosts. Keeps the original 680px reading measure.
+export const ArticleColumn = styled.div`
+  max-width: 680px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+`
+
+// Sticky aside that holds the TableOfContents on desktop. Hidden on mobile
+// (the TOC reappears inline above the article content as a disclosure).
+export const TOCSidebar = styled.aside`
+  display: none;
+
+  ${media.greaterThan("large")`
+    display: block;
+    position: sticky;
+    top: 5.5rem;
+    align-self: start;
+    max-height: calc(100vh - 6rem);
   `}
 `
 
@@ -96,6 +133,9 @@ export const MainContent = styled.section`
   h4,
   h5 {
     margin: 2.4rem 0 1rem;
+    /* Keep headings visible when scrolled to via TOC click — clears the
+       sticky header (~64px ≈ 4rem) plus a touch of breathing room. */
+    scroll-margin-top: 5rem;
   }
 
   ul,

--- a/src/components/TableOfContents/index.js
+++ b/src/components/TableOfContents/index.js
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from "react"
 import * as S from "./styled"
 
-const TableOfContents = () => {
+// Tracks h2/h3 inside `.post-content` and reports which heading is currently
+// "active" (the topmost one crossing the upper portion of the viewport).
+// Shared by both the sticky desktop sidebar and the inline mobile disclosure.
+const useTOCHeadings = () => {
   const [headings, setHeadings] = useState([])
   const [activeId, setActiveId] = useState("")
 
   useEffect(() => {
     // Só executa no browser
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return undefined
 
-    // Extrai headings do conteúdo
     const article = document.querySelector(".post-content")
-    if (!article) return
+    if (!article) return undefined
 
     const headingElements = article.querySelectorAll("h2, h3")
     const headingData = Array.from(headingElements).map((heading, index) => {
@@ -29,16 +31,41 @@ const TableOfContents = () => {
 
     setHeadings(headingData)
 
-    // Observer para marcar heading ativo
+    if (headingData.length === 0) return undefined
+
+    // At the very top of the page no heading crossed the active band yet,
+    // so seed the highlight with the first section (the reader is "in" the
+    // article intro heading toward it). The observer takes over on scroll.
+    setActiveId(headingData[0].id)
+
+    // The IntersectionObserver treats a thin band near the top of the
+    // viewport as the "active" zone (clears the sticky header + breathing
+    // room). When a heading enters that band it becomes the active section;
+    // if multiple are visible at once we keep the uppermost one so it reads
+    // naturally while scrolling both up and down.
     const observer = new IntersectionObserver(
       entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id)
-          }
-        })
+        const intersecting = entries.filter(entry => entry.isIntersecting)
+        if (intersecting.length === 0) return
+
+        // Pick the heading closest to the top of the active band.
+        const topmost = intersecting.reduce((acc, entry) => {
+          if (!acc) return entry
+          return entry.boundingClientRect.top < acc.boundingClientRect.top
+            ? entry
+            : acc
+        }, null)
+
+        if (topmost) setActiveId(topmost.target.id)
       },
-      { rootMargin: "-20% 0px -80% 0px" }
+      {
+        // Top margin accounts for the sticky header (~64px ≈ 4rem) plus
+        // breathing room; bottom margin pulls the active zone up so the
+        // next section only becomes active once it has clearly scrolled in.
+        // NOTE: rootMargin only accepts px/% — rem throws a SyntaxError.
+        rootMargin: "-80px 0px -65% 0px",
+        threshold: 0,
+      }
     )
 
     headingElements.forEach(heading => observer.observe(heading))
@@ -46,32 +73,62 @@ const TableOfContents = () => {
     return () => observer.disconnect()
   }, [])
 
+  return { headings, activeId }
+}
+
+// Smoothly scrolls to a heading while honoring its `scroll-margin-top` so it
+// doesn't hide behind the sticky site header.
+const scrollToHeading = id => {
+  if (typeof document === "undefined") return
+  const element = document.getElementById(id)
+  if (!element) return
+  element.scrollIntoView({ behavior: "smooth", block: "start" })
+}
+
+const renderList = (headings, activeId, onClick, Item, Link) =>
+  headings.map(heading => (
+    <Item key={heading.id} level={heading.level}>
+      <Link
+        href={`#${heading.id}`}
+        isActive={activeId === heading.id}
+        onClick={e => {
+          e.preventDefault()
+          scrollToHeading(heading.id)
+          if (onClick) onClick(heading.id)
+        }}
+      >
+        {heading.text}
+      </Link>
+    </Item>
+  ))
+
+const TableOfContents = ({ variant = "desktop" }) => {
+  const { headings, activeId } = useTOCHeadings()
+
   if (headings.length === 0) return null
+
+  if (variant === "mobile") {
+    return (
+      <S.MobileTOCWrapper>
+        <S.MobileTOCSummary>Neste artigo</S.MobileTOCSummary>
+        <S.MobileTOCList>
+          {renderList(
+            headings,
+            activeId,
+            null,
+            S.MobileTOCItem,
+            S.MobileTOCLink
+          )}
+        </S.MobileTOCList>
+      </S.MobileTOCWrapper>
+    )
+  }
 
   return (
     <S.TOCWrapper aria-label="Neste artigo">
       <S.TOCTitle>Neste artigo</S.TOCTitle>
       <S.TOCList>
-        {headings.map(heading => (
-          <S.TOCItem key={heading.id} level={heading.level}>
-            <S.TOCLink
-              href={`#${heading.id}`}
-              isActive={activeId === heading.id}
-              onClick={e => {
-                e.preventDefault()
-                const element = document.getElementById(heading.id)
-                if (element) {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "start",
-                  })
-                }
-              }}
-            >
-              {heading.text}
-            </S.TOCLink>
-          </S.TOCItem>
-        ))}
+        {renderList(headings, activeId, null, S.TOCItem, S.TOCLink)}
       </S.TOCList>
     </S.TOCWrapper>
   )

--- a/src/components/TableOfContents/styled.js
+++ b/src/components/TableOfContents/styled.js
@@ -1,16 +1,36 @@
 import styled from "styled-components"
 import media from "styled-media-query"
 
+// Desktop nav container. Lives inside the sticky <aside> on desktop and
+// disappears on mobile (where the disclosure variant takes over).
 export const TOCWrapper = styled.nav`
   background: transparent;
   border: 0;
   border-left: 2px solid var(--borders);
   border-radius: 0;
   padding: 0.25rem 0 0.25rem 1rem;
-  margin: 0 0 2.5rem 0;
+  margin: 0;
+
+  /* On desktop, allow long TOC lists to scroll internally so the sidebar
+     never out-grows the viewport. The scrollbar is hidden to avoid jank. */
+  max-height: calc(100vh - 6.5rem);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--borders) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--borders);
+    border-radius: 3px;
+  }
 
   ${media.lessThan("large")`
-    margin-bottom: 2rem;
+    display: none;
   `}
 `
 
@@ -38,19 +58,129 @@ export const TOCItem = styled.li`
   padding-left: ${props => (props.level === 3 ? "1rem" : "0")};
 `
 
+// Active item gets a darker left-border segment that visually extends the
+// wrapper's border. Inactive items get a transparent segment of equal
+// width to keep text alignment consistent.
+// `&&` doubles the class specificity so these colors beat the generic
+// `MainContent a { color: var(--highlight) }` rule (the mobile variant
+// renders inside MainContent).
 export const TOCLink = styled.a`
+  && {
+    color: ${props => (props.isActive ? "var(--highlight)" : "var(--muted)")};
+    text-decoration: none;
+
+    &:hover {
+      color: var(--highlight);
+      opacity: 1;
+    }
+  }
+
   display: block;
-  padding: 0.35rem 0;
-  color: ${props => (props.isActive ? "var(--highlight)" : "var(--muted)")};
-  text-decoration: none;
+  padding: 0.35rem 0 0.35rem 0.75rem;
+  margin-left: -0.75rem;
   font-family: var(--font-body);
   font-size: 0.8125rem;
   line-height: 1.4;
-  border-bottom: none;
-  transition: color 0.2s;
+  border-left: 2px solid
+    ${props => (props.isActive ? "var(--highlight)" : "transparent")};
+  transition: color 0.2s, border-left-color 0.2s;
+`
 
-  &:hover {
-    color: var(--highlight);
-    opacity: 1;
+// --- Mobile disclosure (details/summary) ---------------------------------
+// Renders only on small viewports; hidden on desktop.
+
+export const MobileTOCWrapper = styled.details`
+  display: block;
+  background: transparent;
+  border: 1px solid var(--borders);
+  border-radius: 8px;
+  padding: 0.5rem 1rem 1rem;
+  margin: 0 0 2rem 0;
+
+  ${media.greaterThan("large")`
+    display: none;
+  `}
+`
+
+export const MobileTOCSummary = styled.summary`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  padding: 0.5rem 0;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+
+  &::-webkit-details-marker {
+    display: none;
   }
+
+  &::marker {
+    content: "";
+  }
+
+  &::after {
+    content: "";
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 1.5px solid var(--muted);
+    border-bottom: 1.5px solid var(--muted);
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+  }
+
+  details[open] > &::after {
+    transform: rotate(-135deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--highlight);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+`
+
+export const MobileTOCList = styled.ol`
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  border-left: 2px solid var(--borders);
+  padding-left: 1rem;
+`
+
+export const MobileTOCItem = styled.li`
+  margin: 0;
+  padding: 0;
+  padding-left: ${props => (props.level === 3 ? "1rem" : "0")};
+`
+
+// '&&' beats the generic MainContent 'a' link styling this list nests in.
+export const MobileTOCLink = styled.a`
+  && {
+    color: ${props => (props.isActive ? "var(--highlight)" : "var(--muted)")};
+    text-decoration: none;
+
+    &:hover {
+      color: var(--highlight);
+      opacity: 1;
+    }
+  }
+
+  display: block;
+  padding: 0.35rem 0;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  border-left: 2px solid
+    ${props => (props.isActive ? "var(--highlight)" : "transparent")};
+  padding-left: 0.75rem;
+  margin-left: -0.75rem;
+  transition: color 0.2s, border-left-color 0.2s;
 `

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -30,26 +30,31 @@ const BlogPost = ({ data, pageContext, location }) => {
         location={location}
       ></SEO>
       <article data-pagefind-body>
-        <S.Column>
-          <S.PostHeader>
-            <Breadcrumbs items={breadcrumbItems} />
-            <S.PostDate>
-              {post.frontmatter.date} • {post.timeToRead} min de leitura
-            </S.PostDate>
-            <S.PostTitle>{post.frontmatter.title}</S.PostTitle>
-            <S.PostDescription>
-              {post.frontmatter.description}
-            </S.PostDescription>
-          </S.PostHeader>
-          <S.MainContent>
-            <TableOfContents />
-            <div
-              className="post-content"
-              dangerouslySetInnerHTML={{ __html: post.html }}
-            ></div>
-          </S.MainContent>
-          <RecommendedPosts next={next} previous={previous} />
-        </S.Column>
+        <S.LayoutGrid>
+          <S.TOCSidebar>
+            <TableOfContents variant="desktop" />
+          </S.TOCSidebar>
+          <S.ArticleColumn>
+            <S.PostHeader>
+              <Breadcrumbs items={breadcrumbItems} />
+              <S.PostDate>
+                {post.frontmatter.date} • {post.timeToRead} min de leitura
+              </S.PostDate>
+              <S.PostTitle>{post.frontmatter.title}</S.PostTitle>
+              <S.PostDescription>
+                {post.frontmatter.description}
+              </S.PostDescription>
+            </S.PostHeader>
+            <S.MainContent>
+              <TableOfContents variant="mobile" />
+              <div
+                className="post-content"
+                dangerouslySetInnerHTML={{ __html: post.html }}
+              ></div>
+            </S.MainContent>
+            <RecommendedPosts next={next} previous={previous} />
+          </S.ArticleColumn>
+        </S.LayoutGrid>
       </article>
     </Layout>
   )


### PR DESCRIPTION
Two-column desktop layout: sticky TOC sidebar on the left (240px) beside the 680px reading column; IntersectionObserver highlights the section currently in view with smooth anchor scrolling. Mobile collapses to a details disclosure above the article. Also pins frontmatter.image to String (schema inference typed it as File and broke createPages) and normalizes legacy relative image paths to /assets/img/.